### PR TITLE
Customized config file for CORS

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,27 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*{/}?',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: '*',
+          },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET',
+          },
+          {
+            key : 'Access-Control-Allow-Headers',
+            value : 'Content-Type, Authorization'
+          }
+        ],
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Testing this API on global was giving me a CORS error that I can't access resources from my API. This little configuration can simply resolve this error by adding custom HTTP headers to the next config file. Checkout : [Custom HTTP headers](https://nextjs.org/docs/api-reference/next.config.js/headers  )